### PR TITLE
Output stdout on failure

### DIFF
--- a/bin/cut-release.js
+++ b/bin/cut-release.js
@@ -226,6 +226,8 @@ maybeSelfUpdate(function (err, shouldSelfUpdate) {
 
         function showError (error) {
           log('')
+          log(chalk.red(error.stdout))
+          log('')
           log(chalk.red(error.message))
           log('')
           log(chalk.yellow('You can try again by running these commands manually:'))


### PR DESCRIPTION
When a npm "preversion" or "postversion" script fails, output from that script can be critical for determining the cause of the failure. This PR emits that output when showing the error.
