### PR TITLE
Support npm publish tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,6 @@ Usage: cut-release [<newversion> | patch | minor | major | prepatch | preminor |
     --message, -m   If supplied, npm will use it as a commit message when
                     creating a version commit. If the message contains %s then
                     that will be replaced with the resulting version number
+
+    --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'.
 ```

--- a/bin/cut-release.js
+++ b/bin/cut-release.js
@@ -22,6 +22,7 @@ Object.keys(inquirer.prompt.prompts).forEach(function (prompt) {
 var argv = parseArgs(process.argv.slice(2), {
   alias: {
     y: 'yes',
+    t: 'tag',
     h: 'help'
   },
   unknown: function (opt) {
@@ -201,7 +202,7 @@ maybeSelfUpdate(function (err, shouldSelfUpdate) {
           'npm version ' + version,
           isGitRepo && 'git push origin',
           isGitRepo && 'git push origin --tags',
-          'npm publish'
+          'npm publish' + (argv.tag ? ' --tag ' + argv.tag : '')
         ]
           .filter(Boolean)
 

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -8,3 +8,5 @@ Usage: cut-release [<newversion> | patch | minor | major | prepatch | preminor |
     --message, -m   If supplied, npm will use it as a commit message when
                     creating a version commit. If the message contains %s then
                     that will be replaced with the resulting version number
+
+    --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'.


### PR DESCRIPTION
This PR adds support for specifying a npm tag to use when publishing.
