### PR TITLE
Add NPM tag prompt and --dry-run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,8 @@ Usage: cut-release [<newversion> | patch | minor | major | prepatch | preminor |
                     creating a version commit. If the message contains %s then
                     that will be replaced with the resulting version number
 
-    --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'.
+    --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'. Use this option with
+                    no value to choose from a list of existing tags.
+
+    --dry-run, -d   Print the commands to be executed without actually running them.
 ```

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -9,4 +9,7 @@ Usage: cut-release [<newversion> | patch | minor | major | prepatch | preminor |
                     creating a version commit. If the message contains %s then
                     that will be replaced with the resulting version number
 
-    --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'.
+    --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'. Use this option with
+                    no value to choose from a list of existing tags.
+
+    --dry-run, -d   Print the commands to be executed without actually running them.


### PR DESCRIPTION
This PR is branched from PR #5. It adds support for a NPM tag prompt. 
- When the `--tag` option is omitted, the default "latest" tag is used. The user is not prompted.
- When the `--tag foo` option is specified, the "foo" NPM tag is used. The user is not prompted.
- When the `--tag` option is specified (without a tag name), the user is prompted to choose from a list of tags populated from the `npm dist-tag ls` command. 

The decision to prompt only when `--tag` (without a tag name) is specified anticipates that most users only have a need for NPM's default "latest" tag. An argument could be made that the tag prompt should also be presented when tags other than "latest" have been previously published. That is not implemented in this PR, but I would be happy to contribute that too.

I also added the `--dry-run` option which simply logs each command to be run. During a dry run the `execCmd` function is exited early. This makes it possible to see what commands will be run, without actually running them. If you'd rather have this in its own PR, I can extract it.
