### PR TITLE
Add --preid option to specify prerelease identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,8 @@ Usage: cut-release [<newversion> | patch | minor | major | prepatch | preminor |
                     creating a version commit. If the message contains %s then
                     that will be replaced with the resulting version number
 
-    --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'.
+    --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'. Use this option with
+                    no value to choose from a list of existing tags.
+
+    --dry-run, -d   Print the commands to be executed without actually running them.
 ```

--- a/README.md
+++ b/README.md
@@ -31,5 +31,7 @@ Usage: cut-release [<newversion> | patch | minor | major | prepatch | preminor |
     --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'. Use this option with
                     no value to choose from a list of existing tags.
 
+    --preid, -p     The NPM prerelease identifier to be used when a prerelease version is specified.
+
     --dry-run, -d   Print the commands to be executed without actually running them.
 ```

--- a/bin/cut-release.js
+++ b/bin/cut-release.js
@@ -23,10 +23,13 @@ var argv = parseArgs(process.argv.slice(2), {
   alias: {
     y: 'yes',
     t: 'tag',
+    p: 'preid',
     d: 'dry-run',
     m: 'message',
     h: 'help'
   },
+  string: ['p'],
+  boolean: ['y','d'],
   unknown: function (opt) {
     if (semver.valid(opt) || SEMVER_INCREMENTS.indexOf(opt) > -1) {
       return
@@ -46,6 +49,7 @@ var argv = parseArgs(process.argv.slice(2), {
 var version = argv._[0],
     confirm = argv.yes,
     tag = argv.tag,
+    preid = argv.preid,
     dryRun = argv.d
 
 function log (args) {
@@ -77,7 +81,7 @@ var prompts = [
     message: 'Select semver increment or specify new version',
     when: function(answers) {
       if (version) {
-        answers.version = maybeInc(version)
+        answers.version = version
       }
       return !version
     },
@@ -87,13 +91,7 @@ var prompts = [
         name: 'Other (specify)',
         value: null
       }
-    ]),
-    filter: function (input) {
-      if (!input) {
-        return null
-      }
-      return maybeInc(input)
-    }
+    ])
   },
   {
     type: 'input',
@@ -102,12 +100,61 @@ var prompts = [
     when: function (answers) {
       return !answers.version
     },
-    filter: function (input) {
-      return maybeInc(input)
-    },
     validate: function (input) {
       if (!semver.valid(input)) {
         return 'Please specify a valid semver, e.g. 1.2.3. See http://semver.org/'
+      }
+      return true
+    }
+  },
+  {
+    type: 'list',
+    name: 'preid',
+    message: function (answers) {
+      return 'Select a ' + answers.version + ' identifier'
+    },
+    when: function (answers) {
+      if (preid) {
+        answers.preid = preid
+        return false
+      }
+      if (!answers.version.match(/^pre/) || semver.valid(answers.version)) {
+        return false
+      }
+      var done = this.async()
+      exec('npm show . versions', function (err, stdout) {
+        if (err) return callback(err)
+        var semvers = JSON.parse(stdout.replace(/'/g, '"')).map(function(version) {
+          return semver.parse(version.replace(/[^0-9.a-z\-]/g, ''))
+        }).filter(function(sver) {
+          return sver && sver.prerelease && sver.prerelease.length > 1
+        });
+        if (semvers.length >= 1) {
+          answers.preid = semvers[0].prerelease[0]
+          done(false)
+        } else {
+          done(true)
+        }
+      });
+    },
+    choices: ['rc', 'alpha', 'beta'].concat([
+      new inquirer.Separator(),
+      {
+        name: 'Other (specify)',
+        value: null
+      }
+    ])
+  },
+  {
+    type: 'input',
+    name: 'preid',
+    message: 'Identifier',
+    when: function (answers) {
+      return !answers.preid && answers.version.match(/^pre/)
+    },
+    validate: function (input) {
+      if (!input.match(/[a-z]+/)) {
+        return 'Please specify a valid identifier'
       }
       return true
     }
@@ -157,7 +204,7 @@ var prompts = [
     type: 'confirm',
     name: 'confirm',
     message: function (answers) {
-      var msg = 'Will bump from ' + pkg.version + ' to ' + answers.version + ' and tag as ' + answers.tag + '. Continue'
+      var msg = 'Will bump from ' + pkg.version + ' to ' + maybeInc(answers.version, answers.preid) + ' and tag as ' + answers.tag + '. Continue'
       if (dryRun) {
         msg += ' with dry run'
       }
@@ -174,8 +221,8 @@ var prompts = [
 ]
 
 
-function maybeInc (version) {
-  return SEMVER_INCREMENTS.indexOf(version) > -1 ? semver.inc(pkg.version, version) : version
+function maybeInc (version, preid) {
+  return SEMVER_INCREMENTS.indexOf(version) > -1 ? semver.inc(pkg.version, version, preid) : version
 }
 
 function isGitRepo (callback) {
@@ -259,7 +306,7 @@ maybeSelfUpdate(function (err, shouldSelfUpdate) {
     }
     isGitRepo(function (isGitRepo) {
       var commands = [
-        'npm version ' + answers.version + (argv.message ? ' --message ' + argv.message : ''),
+        'npm version ' + maybeInc(answers.version, answers.preid) + (argv.message ? ' --message ' + argv.message : ''),
         isGitRepo && 'git push origin',
         isGitRepo && 'git push origin --tags',
         'npm publish' + (answers.tag ? ' --tag ' + answers.tag : '')

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -9,4 +9,7 @@ Usage: cut-release [<newversion> | patch | minor | major | prepatch | preminor |
                     creating a version commit. If the message contains %s then
                     that will be replaced with the resulting version number
 
-    --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'.
+    --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'. Use this option with
+                    no value to choose from a list of existing tags.
+
+    --dry-run, -d   Print the commands to be executed without actually running them.

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -12,4 +12,6 @@ Usage: cut-release [<newversion> | patch | minor | major | prepatch | preminor |
     --tag, -t       The NPM tag to use when publishing. Defaults to 'latest'. Use this option with
                     no value to choose from a list of existing tags.
 
+    --preid, -p     The NPM prerelease identifier to be used when a prerelease version is specified.
+
     --dry-run, -d   Print the commands to be executed without actually running them.


### PR DESCRIPTION
This option allows the user to configure the semver [prerelease identifier](https://github.com/npm/node-semver#prerelease-identifiers) using an option or prompt. The prerelease identifier is important when calling cut-release with `premajor`, `preminor`, or `prerelease`.

Example usage:

```
$ cut-release prerelease --dry-run --tag latest --yes --preid beta
Dry run release of new version of `cut-release` (current version: 0.2.1)

=> npm version 0.2.2-beta.0
=> git push origin
=> git push origin --tags
=> npm publish --tag latest
Done
```

If the `--preid` option is not specified and the appropriate prerelease identifier can't be determined by looking at published versions, the user will be prompted with a list of common choices.

```
$ cut-release prerelease --dry-run --tag latest --yes
Dry run release of new version of `cut-release` (current version: 0.2.1)

Select a prerelease identifier: (Use arrow keys)
❯ rc 
  alpha 
  beta 
  ──────────────
  Other (specify)

=> npm version 0.2.2-rc.0
=> git push origin
=> git push origin --tags
=> npm publish --tag latest
Done
```
