### PR TITLE
Increase allowed stdout buffer for forked commands.

### DIFF
--- a/bin/cut-release.js
+++ b/bin/cut-release.js
@@ -136,7 +136,7 @@ function isGitRepo (callback) {
 }
 
 function execCmd (cmd, callback) {
-  exec(cmd, function (err, stdout, stderr) {
+  exec(cmd, {maxBuffer: 1024 * 1024 * 5}, function (err, stdout, stderr) {
     if (err) {
       err = new Error('The command `' + cmd + '` failed:\n' + err.message)
       err.stderr = stderr


### PR DESCRIPTION
Default is 200KiB, and I had `preversion` scripts that were
exceeding that. This increases the limit to 5MiB.

5MiB was a totally arbitrary choice on my part. It is a lot bigger
than I actually needed, but maybe somebody wants to go crazy someday.
It seems unlikely that developer machines won't have orders of
magnitude more memory than that available.
